### PR TITLE
Declared encoding

### DIFF
--- a/lyrics.py
+++ b/lyrics.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import argparse
 from bs4 import BeautifulSoup
 import dbus


### PR DESCRIPTION
If encoding is not declared, I get this error:

```
File "lyrics.py", line 45
SyntaxError: Non-ASCII character '\xc3' in file lyrics.py on line 45, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```
